### PR TITLE
Improve crate docs

### DIFF
--- a/kubetsu-fake/Cargo.toml
+++ b/kubetsu-fake/Cargo.toml
@@ -8,6 +8,8 @@ authors = ["Keiji Yoshimi"]
 
 license = "MIT"
 
+readme = "README.md"
+
 description = "fake support for kubetsu ID types"
 
 homepage = "https://github.com/walf443/kubetsu"

--- a/kubetsu-fake/Cargo.toml
+++ b/kubetsu-fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kubetsu-fake"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.85"
 

--- a/kubetsu-fake/README.md
+++ b/kubetsu-fake/README.md
@@ -1,0 +1,32 @@
+# kubetsu-fake
+
+[fake](https://crates.io/crates/fake) dummy data generation support for [kubetsu](https://crates.io/crates/kubetsu) ID types.
+
+## Usage
+
+```rust
+kubetsu::define_id!(pub struct UserId(i64););
+kubetsu_fake::impl_fake!(UserId(i64));
+
+use fake::{Fake, Faker};
+let _id: UserId = Faker.fake();
+```
+
+Generic form is also supported:
+
+```rust
+kubetsu::define_id!(pub struct MyId<T, U>;);
+kubetsu_fake::impl_fake!(MyId<T, U>);
+
+struct User;
+type UserId = MyId<User, i64>;
+
+use fake::{Fake, Faker};
+let _id: UserId = Faker.fake();
+```
+
+## Install
+
+```bash
+$ cargo add kubetsu kubetsu-fake
+```

--- a/kubetsu-fake/src/lib.rs
+++ b/kubetsu-fake/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 #[doc(hidden)]
 pub mod __private {
     pub use fake;

--- a/kubetsu-serde/Cargo.toml
+++ b/kubetsu-serde/Cargo.toml
@@ -8,6 +8,8 @@ authors = ["Keiji Yoshimi"]
 
 license = "MIT"
 
+readme = "README.md"
+
 description = "serde support for kubetsu ID types"
 
 homepage = "https://github.com/walf443/kubetsu"

--- a/kubetsu-serde/README.md
+++ b/kubetsu-serde/README.md
@@ -1,0 +1,37 @@
+# kubetsu-serde
+
+serde `Serialize` / `Deserialize` support for [kubetsu](https://crates.io/crates/kubetsu) ID types.
+
+## Usage
+
+```rust
+kubetsu::define_id!(pub struct UserId(i64););
+kubetsu_serde::impl_serde!(UserId(i64));
+
+let id = UserId::new(42);
+let json = serde_json::to_string(&id).unwrap();
+assert_eq!(json, "42");
+
+let deserialized: UserId = serde_json::from_str(&json).unwrap();
+assert_eq!(*deserialized.inner(), 42);
+```
+
+Generic form is also supported:
+
+```rust
+kubetsu::define_id!(pub struct MyId<T, U>;);
+kubetsu_serde::impl_serde!(MyId<T, U>);
+
+struct User;
+type UserId = MyId<User, i64>;
+
+let id = UserId::new(42);
+let json = serde_json::to_string(&id).unwrap();
+assert_eq!(json, "42");
+```
+
+## Install
+
+```bash
+$ cargo add kubetsu kubetsu-serde
+```

--- a/kubetsu-serde/src/lib.rs
+++ b/kubetsu-serde/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 #[doc(hidden)]
 pub mod __private {
     pub use kubetsu;

--- a/kubetsu-sqlx/Cargo.toml
+++ b/kubetsu-sqlx/Cargo.toml
@@ -8,6 +8,8 @@ authors = ["Keiji Yoshimi"]
 
 license = "MIT"
 
+readme = "README.md"
+
 description = "sqlx support for kubetsu ID types"
 
 homepage = "https://github.com/walf443/kubetsu"

--- a/kubetsu-sqlx/README.md
+++ b/kubetsu-sqlx/README.md
@@ -1,0 +1,27 @@
+# kubetsu-sqlx
+
+[sqlx](https://crates.io/crates/sqlx) `Type` / `Encode` / `Decode` support for [kubetsu](https://crates.io/crates/kubetsu) ID types.
+
+## Usage
+
+```rust,ignore
+kubetsu::define_id!(pub struct UserId(i64););
+kubetsu_sqlx::impl_sqlx!(UserId(i64));
+```
+
+Which database backends are supported depends on the enabled features:
+`any`, `mysql`, `postgres`, `sqlite`.
+
+Generic form is also supported:
+
+```rust,ignore
+kubetsu::define_id!(pub struct MyId<T, U>;);
+kubetsu_sqlx::impl_sqlx!(MyId<T, U>);
+```
+
+## Install
+
+```bash
+$ cargo add kubetsu
+$ cargo add kubetsu-sqlx --features sqlite  # choose your backend
+```

--- a/kubetsu-sqlx/README.md
+++ b/kubetsu-sqlx/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-```rust,ignore
+```rust
 kubetsu::define_id!(pub struct UserId(i64););
 kubetsu_sqlx::impl_sqlx!(UserId(i64));
 ```
@@ -14,7 +14,7 @@ Which database backends are supported depends on the enabled features:
 
 Generic form is also supported:
 
-```rust,ignore
+```rust
 kubetsu::define_id!(pub struct MyId<T, U>;);
 kubetsu_sqlx::impl_sqlx!(MyId<T, U>);
 ```

--- a/kubetsu-sqlx/src/lib.rs
+++ b/kubetsu-sqlx/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 #[doc(hidden)]
 pub mod __private {
     pub use kubetsu;

--- a/kubetsu-sqlx/src/lib.rs
+++ b/kubetsu-sqlx/src/lib.rs
@@ -13,14 +13,14 @@ pub mod __private {
 ///
 /// # Concrete form
 ///
-/// ```rust,ignore
+/// ```rust
 /// kubetsu::define_id!(pub struct UserId(i64););
 /// kubetsu_sqlx::impl_sqlx!(UserId(i64));
 /// ```
 ///
 /// # Generic form
 ///
-/// ```rust,ignore
+/// ```rust
 /// kubetsu::define_id!(pub struct MyId<T, U>;);
 /// kubetsu_sqlx::impl_sqlx!(MyId<T, U>);
 /// ```


### PR DESCRIPTION
## Summary

- Add README.md to each adapter crate (kubetsu-serde, kubetsu-fake, kubetsu-sqlx) for better crates.io experience
- Include README as crate-level rustdoc via `#![doc = include_str!]`
- Enable doc-tests for all adapter crate examples (previously `ignore` due to feature flag requirements)
- Bump kubetsu-fake to v0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)