### PR TITLE
Add no_std support to kubetsu core crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           targets: thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -p kubetsu --target thumbv7em-none-eabihf
+      - run: cargo build -p kubetsu -p kubetsu-serde --target thumbv7em-none-eabihf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
+          components: clippy
           targets: thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -p kubetsu -p kubetsu-serde --target thumbv7em-none-eabihf
+      - run: cargo build -p kubetsu-no-std-tests --target thumbv7em-none-eabihf
+      - run: cargo clippy -p kubetsu-no-std-tests --target thumbv7em-none-eabihf -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --features kubetsu-sqlx/any,kubetsu-sqlx/mysql,kubetsu-sqlx/postgres,kubetsu-sqlx/sqlite
+
+  no_std:
+    name: Build (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabihf
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build -p kubetsu --target thumbv7em-none-eabihf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "kubetsu-fake",
     "kubetsu-sqlx",
     "kubetsu-tests",
+    "kubetsu-no-std-tests",
 ]

--- a/kubetsu-no-std-tests/Cargo.toml
+++ b/kubetsu-no-std-tests/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 [dependencies]
 kubetsu = { path = "../kubetsu" }
 kubetsu-serde = { path = "../kubetsu-serde" }
-serde = { version = "1", default-features = false }

--- a/kubetsu-no-std-tests/Cargo.toml
+++ b/kubetsu-no-std-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kubetsu-no-std-tests"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+kubetsu = { path = "../kubetsu" }
+kubetsu-serde = { path = "../kubetsu-serde" }
+serde = { version = "1", default-features = false }

--- a/kubetsu-no-std-tests/src/lib.rs
+++ b/kubetsu-no-std-tests/src/lib.rs
@@ -1,0 +1,13 @@
+//! Verifies that `kubetsu::define_id!` and `kubetsu_serde::impl_serde!`
+//! expand to code that compiles in a `#![no_std]` consumer crate.
+//!
+//! This crate has no runtime tests; the act of building it for a no_std
+//! target (e.g. `thumbv7em-none-eabihf`) is the test.
+
+#![no_std]
+
+kubetsu::define_id!(pub struct UserId(i64););
+kubetsu_serde::impl_serde!(UserId(i64));
+
+kubetsu::define_id!(pub struct MyId<T, U>;);
+kubetsu_serde::impl_serde!(MyId<T, U>);

--- a/kubetsu-no-std-tests/src/lib.rs
+++ b/kubetsu-no-std-tests/src/lib.rs
@@ -6,5 +6,7 @@
 
 #![no_std]
 
-kubetsu::define_id!(pub struct MyId<T, U>;);
+kubetsu::define_id!(
+    pub struct MyId<T, U>;
+);
 kubetsu_serde::impl_serde!(MyId<T, U>);

--- a/kubetsu-no-std-tests/src/lib.rs
+++ b/kubetsu-no-std-tests/src/lib.rs
@@ -6,8 +6,5 @@
 
 #![no_std]
 
-kubetsu::define_id!(pub struct UserId(i64););
-kubetsu_serde::impl_serde!(UserId(i64));
-
 kubetsu::define_id!(pub struct MyId<T, U>;);
 kubetsu_serde::impl_serde!(MyId<T, U>);

--- a/kubetsu-serde/Cargo.toml
+++ b/kubetsu-serde/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 description = "serde support for kubetsu ID types"
 
-keywords = ["no-std", "serde", "newtype", "id"]
+keywords = ["serde", "newtype", "id", "no-std"]
 categories = ["encoding", "no-std"]
 
 homepage = "https://github.com/walf443/kubetsu"

--- a/kubetsu-serde/Cargo.toml
+++ b/kubetsu-serde/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 description = "serde support for kubetsu ID types"
 
 keywords = ["no-std", "serde", "newtype", "id"]
-categories = ["no-std", "encoding"]
+categories = ["encoding", "no-std"]
 
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"

--- a/kubetsu-serde/Cargo.toml
+++ b/kubetsu-serde/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 
 description = "serde support for kubetsu ID types"
 
+keywords = ["no-std", "serde", "newtype", "id"]
+categories = ["no-std", "encoding"]
+
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"
 

--- a/kubetsu-serde/README.md
+++ b/kubetsu-serde/README.md
@@ -30,6 +30,12 @@ let json = serde_json::to_string(&id).unwrap();
 assert_eq!(json, "42");
 ```
 
+## `no_std` support
+
+This crate works in `#![no_std]` environments. The `impl_serde!` macro
+expands to `::core::*` paths only and the `serde` dependency is pulled
+with `default-features = false`.
+
 ## Install
 
 ```bash

--- a/kubetsu-serde/src/lib.rs
+++ b/kubetsu-serde/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
 
 #[doc(hidden)]

--- a/kubetsu/Cargo.toml
+++ b/kubetsu/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 description = "distinguish value type of other struct"
 
 keywords = ["no-std", "newtype", "id", "type-safety"]
-categories = ["no-std", "rust-patterns"]
+categories = ["rust-patterns", "no-std"]
 
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"

--- a/kubetsu/Cargo.toml
+++ b/kubetsu/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT"
 
 description = "distinguish value type of other struct"
 
+keywords = ["no-std", "newtype", "id", "type-safety"]
+categories = ["no-std", "rust-patterns"]
+
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"
 

--- a/kubetsu/Cargo.toml
+++ b/kubetsu/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 description = "distinguish value type of other struct"
 
-keywords = ["no-std", "newtype", "id", "type-safety"]
+keywords = ["newtype", "id", "type-safety", "no-std"]
 categories = ["rust-patterns", "no-std"]
 
 homepage = "https://github.com/walf443/kubetsu"

--- a/kubetsu/README.md
+++ b/kubetsu/README.md
@@ -118,6 +118,14 @@ fn main() {
 }
 ```
 
+# `no_std` support
+
+`kubetsu` and `kubetsu-serde` work in `#![no_std]` crates. The
+`define_id!` macro expands to `::core::*` paths only, so it has no
+dependency on `std` or `alloc`. Adapter crates `kubetsu-fake` and
+`kubetsu-sqlx` remain `std`-only because their upstream dependencies
+require `std`.
+
 # Install
 
 ```bash

--- a/kubetsu/src/lib.rs
+++ b/kubetsu/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
 mod macros;
 
 mod id;

--- a/kubetsu/src/macros/mod.rs
+++ b/kubetsu/src/macros/mod.rs
@@ -47,7 +47,7 @@ macro_rules! define_id {
         $(#[$meta])*
         $vis struct $name<$phantom, $inner> {
             inner: $inner,
-            _phantom: ::std::marker::PhantomData<$phantom>,
+            _phantom: ::core::marker::PhantomData<$phantom>,
         }
 
         impl<$phantom, $inner> $name<$phantom, $inner> {
@@ -55,7 +55,7 @@ macro_rules! define_id {
             pub fn new(inner: $inner) -> Self {
                 Self {
                     inner,
-                    _phantom: ::std::marker::PhantomData,
+                    _phantom: ::core::marker::PhantomData,
                 }
             }
 
@@ -71,7 +71,7 @@ macro_rules! define_id {
             fn new(inner: $inner) -> Self {
                 Self {
                     inner,
-                    _phantom: ::std::marker::PhantomData,
+                    _phantom: ::core::marker::PhantomData,
                 }
             }
 
@@ -131,33 +131,33 @@ macro_rules! define_id {
 macro_rules! __impl_id_core_traits {
     // Concrete type (no generics)
     ([] $name:ty, $inner:ty) => {
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 self.inner().fmt(f)
             }
         }
 
-        impl ::std::cmp::PartialEq for $name {
+        impl ::core::cmp::PartialEq for $name {
             fn eq(&self, other: &Self) -> bool {
                 self.inner().eq(other.inner())
             }
         }
 
-        impl ::std::cmp::Eq for $name {}
+        impl ::core::cmp::Eq for $name {}
 
-        impl ::std::hash::Hash for $name {
-            fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+        impl ::core::hash::Hash for $name {
+            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                 self.inner().hash(state)
             }
         }
 
-        impl ::std::clone::Clone for $name {
+        impl ::core::clone::Clone for $name {
             fn clone(&self) -> Self {
                 Self::new(self.inner().clone())
             }
         }
 
-        impl ::std::convert::From<$inner> for $name {
+        impl ::core::convert::From<$inner> for $name {
             fn from(value: $inner) -> Self {
                 Self::new(value)
             }
@@ -165,35 +165,35 @@ macro_rules! __impl_id_core_traits {
     };
     // Generic type (e.g. Id<T, U>)
     ([$($gen:tt)+] $name:ty, $inner:ty) => {
-        impl<$($gen)+> ::std::fmt::Debug for $name where $inner: ::std::fmt::Debug {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        impl<$($gen)+> ::core::fmt::Debug for $name where $inner: ::core::fmt::Debug {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 self.inner().fmt(f)
             }
         }
 
-        impl<$($gen)+> ::std::cmp::PartialEq for $name where $inner: ::std::cmp::PartialEq {
+        impl<$($gen)+> ::core::cmp::PartialEq for $name where $inner: ::core::cmp::PartialEq {
             fn eq(&self, other: &Self) -> bool {
                 self.inner().eq(other.inner())
             }
         }
 
-        impl<$($gen)+> ::std::cmp::Eq for $name where $inner: ::std::cmp::Eq {}
+        impl<$($gen)+> ::core::cmp::Eq for $name where $inner: ::core::cmp::Eq {}
 
         /// you can use as hash key if value implement [Hash].
-        impl<$($gen)+> ::std::hash::Hash for $name where $inner: ::std::cmp::PartialEq + ::std::hash::Hash {
-            fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+        impl<$($gen)+> ::core::hash::Hash for $name where $inner: ::core::cmp::PartialEq + ::core::hash::Hash {
+            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                 self.inner().hash(state)
             }
         }
 
         /// you can clone if value implement [Clone].
-        impl<$($gen)+> ::std::clone::Clone for $name where $inner: ::std::clone::Clone {
+        impl<$($gen)+> ::core::clone::Clone for $name where $inner: ::core::clone::Clone {
             fn clone(&self) -> Self {
                 Self::new(self.inner().clone())
             }
         }
 
-        impl<$($gen)+> ::std::convert::From<$inner> for $name {
+        impl<$($gen)+> ::core::convert::From<$inner> for $name {
             fn from(value: $inner) -> Self {
                 Self::new(value)
             }


### PR DESCRIPTION
## Summary

Add `no_std` support to the `kubetsu` and `kubetsu-serde` crates.

- `kubetsu`: replace `::std::*` paths with `::core::*` in the `define_id!` macro expansion so it works inside `#![no_std]` consumer crates, and mark the crate `no_std` (except under `cfg(test)` where the test harness needs std).
- `kubetsu-serde`: mark the crate `no_std` (its `serde` dependency was already pulled with `default-features = false`, but the crate itself implicitly required std).
- Adapter crates `kubetsu-fake` and `kubetsu-sqlx` remain `std`-only because their upstream dependencies (`fake`, `sqlx`) require `std`.
- Add a new `kubetsu-no-std-tests` workspace member (publish=false) that calls `define_id!` and `impl_serde!` from a real `#![no_std]` crate — the CI no_std job builds it on `thumbv7em-none-eabihf`, so any future `::std::*` regression in macro expansion is caught.
- Run clippy on the no_std target as well.
- Document `no_std` support in the README and add `no-std` to `keywords`/`categories` of both published crates.

## Test plan

- [x] `cargo test --workspace --features kubetsu-sqlx/sqlite` passes (host)
- [x] `cargo build -p kubetsu-no-std-tests --target thumbv7em-none-eabihf` succeeds
- [x] `cargo clippy -p kubetsu-no-std-tests --target thumbv7em-none-eabihf -- -D warnings` clean
- [x] CI `no_std` job covers both build and clippy on the embedded target