### PR TITLE
Add keywords and categories to kubetsu-fake and kubetsu-sqlx

### DIFF
--- a/kubetsu-fake/Cargo.toml
+++ b/kubetsu-fake/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 
 description = "fake support for kubetsu ID types"
 
+keywords = ["fake", "dummy", "newtype", "id", "testing"]
+categories = ["development-tools::testing"]
+
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"
 

--- a/kubetsu-sqlx/Cargo.toml
+++ b/kubetsu-sqlx/Cargo.toml
@@ -12,8 +12,7 @@ readme = "README.md"
 
 description = "sqlx support for kubetsu ID types"
 
-keywords = ["sqlx", "database", "newtype", "id"]
-categories = ["database"]
+keywords = ["sqlx", "newtype", "id"]
 
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"

--- a/kubetsu-sqlx/Cargo.toml
+++ b/kubetsu-sqlx/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 
 description = "sqlx support for kubetsu ID types"
 
+keywords = ["sqlx", "database", "newtype", "id"]
+categories = ["database"]
+
 homepage = "https://github.com/walf443/kubetsu"
 repository = "https://github.com/walf443/kubetsu.git"
 


### PR DESCRIPTION
Improve crates.io discoverability for the adapter crates. These crates are not no_std-compatible (their upstream deps require std), so the no-std keyword/category is intentionally omitted.